### PR TITLE
NULL assertion fix in FIFO, was PR #766

### DIFF
--- a/rtl/core/neorv32_fifo.vhd
+++ b/rtl/core/neorv32_fifo.vhd
@@ -145,7 +145,13 @@ begin
         fifo_mem <= (others => (others => '0')); -- full reset of memory cells
       elsif rising_edge(clk_i) then
         if (we = '1') then
-          fifo_mem(to_integer(unsigned(w_pnt(w_pnt'left-1 downto 0)))) <= wdata_i;
+          -- Added fifo_depth check to the read out path to preven a NULL assertion for
+          -- fifo_depth_c of 1.
+          if (fifo_depth_c > 1) then 
+            fifo_mem(to_integer(unsigned(w_pnt(w_pnt'left-1 downto 0)))) <= wdata_i;
+          else
+            fifo_mem(0) <= wdata_i;
+          end if;
         end if;
       end if;
     end process fifo_write;
@@ -157,7 +163,11 @@ begin
     begin
       if rising_edge(clk_i) then
         if (we = '1') then
-          fifo_mem(to_integer(unsigned(w_pnt(w_pnt'left-1 downto 0)))) <= wdata_i;
+          if (fifo_depth_c > 1) then 
+            fifo_mem(to_integer(unsigned(w_pnt(w_pnt'left-1 downto 0)))) <= wdata_i;
+          else
+            fifo_mem(0) <= wdata_i;
+          end if;
         end if;
       end if;
     end process fifo_write;
@@ -168,7 +178,9 @@ begin
   -- -------------------------------------------------------------------------------------------
   fifo_read_async: -- asynchronous read
   if not FIFO_RSYNC generate
-    rdata_o <= fifo_mem(to_integer(unsigned(r_pnt(r_pnt'left-1 downto 0))));
+    -- Added fifo_depth check to the read out path to preven a NULL assertion for
+    -- fifo_depth_c of 1.
+    rdata_o <= fifo_mem(to_integer(unsigned(r_pnt(r_pnt'left-1 downto 0)))) when (fifo_depth_c > 1) else fifo_mem(0);
     -- status --
     free_o  <= free;
     avail_o <= avail;
@@ -180,7 +192,13 @@ begin
     sync_read: process(clk_i)
     begin
       if rising_edge(clk_i) then
-        rdata_o <= fifo_mem(to_integer(unsigned(r_pnt(r_pnt'left-1 downto 0))));
+        -- Added fifo_depth check to the read out path to preven a NULL assertion for
+        -- fifo_depth_c of 1.
+        if (fifo_depth_c > 1) then 
+          rdata_o <= fifo_mem(to_integer(unsigned(r_pnt(r_pnt'left-1 downto 0))));
+        else
+          rdata_o <= fifo_mem(0);
+        end if;
       end if;
     end process sync_read;
     -- status --


### PR DESCRIPTION
Added condition check on fifo_dept_c to ensure we don't get NULL assertions when fifo_depth_c == 1. Reset function already added.